### PR TITLE
Add changes.jsonl and pin esbuild

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+changes.jsonl merge=union

--- a/changes.jsonl
+++ b/changes.jsonl
@@ -1,0 +1,47 @@
+{"type":"release","version":"0.1.0","date":"2025-01-05"}
+{"description":"Fix missing README","category":"fix"}
+{"type":"release","version":"0.1.1","date":"2025-01-05"}
+{"description":"Issues with vite plugin","category":"fix"}
+{"type":"release","version":"0.2.0","date":"2025-01-05"}
+{"description":"Use virtual module for vite","category":"change"}
+{"description":"Force plugin to run first with enforce: 'pre'","category":"change"}
+{"type":"release","version":"0.2.1","date":"2025-01-06"}
+{"description":"Use packages and examples monorepo structure","category":"change"}
+{"description":"Explicitly export types.","category":"change"}
+{"type":"release","version":"1.0.0","date":"2025-01-16"}
+{"description":"Incorrect export","category":"fix"}
+{"type":"release","version":"1.0.1","date":"2025-01-16"}
+{"description":"win32 support (dotnet-gitversion.exe)","category":"feature"}
+{"description":"strict option (raise error if gitversion fails, defaults to false)","category":"feature"}
+{"type":"release","version":"1.1.0","date":"2025-05-08"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.2.0","date":"2025-08-03"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.0","date":"2025-08-27"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.1","date":"2025-10-24"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.2","date":"2025-12-26"}
+{"description":"Fixed CVE-2026-25547 in @isaacs/brace-expansion","category":"security","metadata":{"cve":"CVE-2026-25547","ghsa":"GHSA-7h2j-956f-4vf2"}}
+{"description":"Updated @shellicar/build-clean to 1.2.1","category":"change"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.3","date":"2026-02-05"}
+{"description":"Fixed GHSA-3ppc-4f35-3m26 in minimatch","category":"security","metadata":{"ghsa":"GHSA-3ppc-4f35-3m26"}}
+{"description":"Fixed GHSA-7r86-cg39-jmmj in minimatch","category":"security","metadata":{"ghsa":"GHSA-7r86-cg39-jmmj"}}
+{"description":"Fixed GHSA-23c5-xmqv-rm74 in minimatch","category":"security","metadata":{"ghsa":"GHSA-23c5-xmqv-rm74"}}
+{"description":"Fixed GHSA-mw96-cpmx-2vgc in rollup","category":"security","metadata":{"ghsa":"GHSA-mw96-cpmx-2vgc"}}
+{"description":"Fixed GHSA-7gcc-r8m5-44qm in koa","category":"security","metadata":{"ghsa":"GHSA-7gcc-r8m5-44qm"}}
+{"description":"Fixed GHSA-5c6j-r48x-rmvq in serialize-javascript","category":"security","metadata":{"ghsa":"GHSA-5c6j-r48x-rmvq"}}
+{"description":"Fixed GHSA-2g4f-4pwh-qvx6 in ajv","category":"security","metadata":{"ghsa":"GHSA-2g4f-4pwh-qvx6"}}
+{"description":"Updated rollup to 4.59, @shellicar/build-clean to 1.2.3","category":"change"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.4","date":"2026-02-28"}
+{"description":"Fixed GHSA-38f7-945m-qr2g in effect","category":"security","metadata":{"ghsa":"GHSA-38f7-945m-qr2g"}}
+{"description":"Fixed GHSA-c2c7-rcm5-vvqj in picomatch","category":"security","metadata":{"ghsa":"GHSA-c2c7-rcm5-vvqj"}}
+{"description":"Fixed GHSA-3v7f-55p6-f55p in picomatch","category":"security","metadata":{"ghsa":"GHSA-3v7f-55p6-f55p"}}
+{"description":"Fixed GHSA-48c2-rrv3-qjmp in yaml","category":"security","metadata":{"ghsa":"GHSA-48c2-rrv3-qjmp"}}
+{"description":"Fixed GHSA-f886-m6hf-6m8v in brace-expansion","category":"security","metadata":{"ghsa":"GHSA-f886-m6hf-6m8v"}}
+{"description":"Updated @shellicar/build-clean to 1.3.2","category":"change"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.5","date":"2026-03-28"}
+{"description":"Pin esbuild version to silence false Dependabot CVE alerts","category":"change"}

--- a/packages/build-version/package.json
+++ b/packages/build-version/package.json
@@ -194,7 +194,7 @@
     "@farmfe/core": ">=1",
     "@nuxt/kit": "^3",
     "@nuxt/schema": "^3",
-    "esbuild": "*",
+    "esbuild": "^0.27",
     "rollup": "^3",
     "vite": "^6",
     "webpack": "^4 || ^5"
@@ -230,6 +230,7 @@
     "@types/node": "^25.5.0",
     "bumpp": "^10.4.1",
     "chalk": "^5.6.2",
+    "esbuild": "^0.27.4",
     "esno": "^4.8.0",
     "npm-run-all2": "^8.0.4",
     "rollup": "^4.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       '@farmfe/core':
         specifier: '>=1'
         version: 1.7.11(@types/node@25.5.0)
-      esbuild:
-        specifier: '*'
-        version: 0.27.4
       unplugin:
         specifier: ^2.3.11
         version: 2.3.11
@@ -166,6 +163,9 @@ importers:
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
       esno:
         specifier: ^4.8.0
         version: 4.8.0


### PR DESCRIPTION
## Summary

- Add changes.jsonl as structured changelog from CHANGELOG.md
- Add .gitattributes with merge=union for changes.jsonl
- Pin esbuild to ^0.27 (peer) and ^0.27.4 (dev) to silence false Dependabot CVE alerts