### PR TITLE
Release 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.6] - 2026-03-28
+
+### Changed
+
+- Pinned esbuild version to silence false Dependabot CVE alerts
+
 ## [1.3.5] - 2026-03-28
 
 ### Security
@@ -113,6 +119,7 @@ Fix missing README
 
 Initial release.
 
+[1.3.6]: https://github.com/shellicar/build-version/releases/tag/1.3.6
 [1.3.5]: https://github.com/shellicar/build-version/releases/tag/1.3.5
 [1.3.4]: https://github.com/shellicar/build-version/releases/tag/1.3.4
 [1.3.3]: https://github.com/shellicar/build-version/releases/tag/1.3.3

--- a/packages/build-version/package.json
+++ b/packages/build-version/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shellicar/build-version",
   "private": false,
-  "version": "1.3.5",
+  "version": "1.3.6",
   "type": "module",
   "license": "MIT",
   "author": "Stephen Hellicar",


### PR DESCRIPTION
## Summary

- Bump version to 1.3.6
- Pin esbuild version to silence false Dependabot CVE alerts